### PR TITLE
Add post-link script to install `faiss-cpu` via `pip`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -42,7 +42,6 @@ test:
   imports:
     - jupyter_ai
   commands:
-    - pip install "faiss-cpu<=1.8.0"
     - pip check
 
 about:

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,0 +1,1 @@
+$PREFIX/bin/pip install "faiss-cpu<=1.8.0"


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

## Context

- This PR is being made to bring Python 3.12 support to Jupyter AI when installed via Conda Forge.
- Only `faiss-cpu==1.8.0` has distributions that support Python 3.12 environments. However, this is not available on Conda Forge yet: https://github.com/conda-forge/faiss-split-feedstock/pull/75.
   - Even though installing packages via `pip` in a post-link script is not good practice, this is the only way to ensure Python 3.12 support for all Jupyter AI users.
- `faiss-cpu==1.8.0.post1` is also missing distributions for macOS: https://github.com/jupyterlab/jupyter-ai/issues/858
- Hence, I'm installing `faiss-cpu` via `pip install "faiss-cpu<=1.8.0"`.