### PR TITLE
Remove `faiss-cpu` from run reqs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -32,9 +32,9 @@ requirements:
     - dask-core
     - typing-extensions >=4.5.0
     - distributed
-    - faiss-cpu
     - traitlets >=5.0,<6
     - deepmerge >=1.0,<2
+    # faiss-cpu>=1.8.0 is installed via `./post-link.sh`
 
 test:
   requires:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

## Context

Installing `jupyter-ai==2.19.0` via `conda` still results in the following error due to `faiss-cpu` being listed as a run requirement:

```
 % mmi jupyter-ai
conda-forge/osx-64                                          Using cache
  1 {% set name = "jupyter-ai" %}
conda-forge/noarch                                          Using cache
pkgs/main/noarch                                              No change
pkgs/main/osx-64                                              No change
pkgs/r/osx-64                                                 No change
pkgs/r/noarch                                                 No change

Pinned packages:
  - python 3.12.*

error    libmamba Could not solve for environment specs
    The following packages are incompatible
    ├─ jupyter-ai is installable with the potential options
    │  ├─ jupyter-ai 2.2.0 would require
    │  │  ├─ langchain 0.0.277 , which requires
    │  │  │  └─ tiktoken >=0.3.2,<0.4.0 , which can be installed;
    │  │  └─ tiktoken with the potential options
    │  │     ├─ tiktoken [0.3.1|0.3.2|...|0.7.0] would require
    │  │     │  └─ python >=3.10,<3.11.0a0 , which can be installed;
    │  │     ├─ tiktoken [0.3.1|0.3.2|...|0.7.0] would require
    │  │     │  └─ python >=3.11,<3.12.0a0 , which can be installed;
    │  │     ├─ tiktoken [0.3.1|0.3.2|...|0.7.0] would require
    │  │     │  └─ python >=3.8,<3.9.0a0 , which can be installed;
    │  │     ├─ tiktoken [0.3.1|0.3.2|...|0.7.0] would require
    │  │     │  └─ python >=3.9,<3.10.0a0 , which can be installed;
    │  │     └─ tiktoken [0.5.1|0.5.2|0.6.0|0.7.0] conflicts with any installable versions previously reported;
    │  └─ jupyter-ai [2.10.0|2.11.0|...|2.9.1] would require
    │     ├─ faiss-cpu with the potential options
    │     │  ├─ faiss-cpu 1.6.3 would require
    │     │  │  └─ python_abi 3.6.* *_cp36m, which requires
    │     │  │     └─ python 3.6.* , which can be installed;
    │     │  ├─ faiss-cpu 1.6.3 would require
    │     │  │  └─ python_abi 3.7.* *_cp37m with the potential options
    │     │  │     ├─ python_abi 3.7 would require
    │     │  │     │  └─ python 3.7.* , which can be installed;
    │     │  │     └─ python_abi 3.7 would require
    │     │  │        └─ python 3.7.* *_cpython, which can be installed;
    │     │  ├─ faiss-cpu 1.6.3 would require
    │     │  │  └─ python_abi 3.8.* *_cp38 with the potential options
    │     │  │     ├─ python_abi 3.8 would require
    │     │  │     │  └─ python 3.8.* , which can be installed;
    │     │  │     └─ python_abi 3.8 would require
    │     │  │        └─ python 3.8.* *_cpython, which can be installed;
    │     │  ├─ faiss-cpu [1.6.4|1.6.5|1.7.0] would require
    │     │  │  └─ faiss [1.6.4 *_cpu|1.6.5 *_cpu|1.7.0 *_cpu] with the potential options
    │     │  │     ├─ faiss [1.6.4|1.6.5|1.7.0|1.7.1|1.7.2] would require
    │     │  │     │  └─ python >=3.7,<3.8.0a0 , which can be installed;
    │     │  │     ├─ faiss [1.6.4|1.6.5|...|1.7.4] would require
    │     │  │     │  └─ python >=3.8,<3.9.0a0 , which can be installed;
    │     │  │     ├─ faiss [1.6.4|1.6.5|...|1.7.4] would require
    │     │  │     │  └─ python >=3.9,<3.10.0a0 , which can be installed;
    │     │  │     └─ faiss [1.6.4|1.6.5|1.7.0] would require
    │     │  │        └─ python >=3.6,<3.7.0a0 , which can be installed;
    │     │  ├─ faiss-cpu 1.7.1 would require
    │     │  │  └─ faiss 1.7.1 *_cpu with the potential options
    │     │  │     ├─ faiss [1.7.1|1.7.2|1.7.3|1.7.4] would require
    │     │  │     │  └─ python >=3.10,<3.11.0a0 , which can be installed;
    │     │  │     ├─ faiss [1.6.4|1.6.5|1.7.0|1.7.1|1.7.2], which can be installed (as previously explained);
    │     │  │     ├─ faiss [1.6.4|1.6.5|...|1.7.4], which can be installed (as previously explained);
    │     │  │     └─ faiss [1.6.4|1.6.5|...|1.7.4], which can be installed (as previously explained);
    │     │  ├─ faiss-cpu 1.7.2 would require
    │     │  │  └─ faiss 1.7.2 *_cpu with the potential options
    │     │  │     ├─ faiss [1.7.1|1.7.2|1.7.3|1.7.4], which can be installed (as previously explained);
    │     │  │     ├─ faiss [1.6.4|1.6.5|1.7.0|1.7.1|1.7.2], which can be installed (as previously explained);
    │     │  │     ├─ faiss [1.6.4|1.6.5|...|1.7.4], which can be installed (as previously explained);
    │     │  │     ├─ faiss [1.6.4|1.6.5|...|1.7.4], which can be installed (as previously explained);
    │     │  │     └─ faiss [1.7.2|1.7.3|1.7.4] would require
    │     │  │        └─ python >=3.11,<3.12.0a0 , which can be installed;
    │     │  └─ faiss-cpu [1.7.3|1.7.4] would require
    │     │     └─ faiss [1.7.3 *_cpu|1.7.4 *_cpu], which can be installed (as previously explained);
    │     └─ python >=3.8  with the potential options
    │        ├─ python [3.12.0|3.12.1|3.12.2|3.12.3|3.12.4] conflicts with any installable versions previously reported;
    │        ├─ python [3.10.0|3.10.1|...|3.10.9], which can be installed;
    │        ├─ python [3.11.0|3.11.1|...|3.11.9], which can be installed;
    │        ├─ python [3.8.0|3.8.1|...|3.8.8], which can be installed;
    │        ├─ python [3.9.0|3.9.1|...|3.9.9], which can be installed;
    │        └─ python 3.12.0rc3 would require
    │           └─ _python_rc, which does not exist (perhaps a missing channel);
    └─ pin-1 is not installable because it requires
       └─ python 3.12.* , which conflicts with any installable versions previously reported.
critical libmamba Could not solve for environment specs
```