### PR TITLE
Rebuild jupyter-ai v2.31.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
Can't install 2.31.1 from Conda Forge for some reason, trying to increase the build number and trigger Conda Forge deployment once more, see https://anaconda.org/conda-forge/jupyter-ai/files